### PR TITLE
アバター画像にjpegファイルが使用できない問題を解消します

### DIFF
--- a/flarum/Dockerfile
+++ b/flarum/Dockerfile
@@ -15,6 +15,7 @@ RUN \
     libgd-dev unzip && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
+  docker-php-ext-configure gd --with-freetype-dir=/usr/include/ --with-jpeg-dir=/usr/include/ && \
   docker-php-ext-install -j$(nproc) pdo_mysql gd && \
   \
   php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php');" && \

--- a/nginx/flarum.conf
+++ b/nginx/flarum.conf
@@ -3,6 +3,7 @@ server {
     server_name _;
     root        /var/www/html;
     index       index.php index.html;
+    client_max_body_size 8388608;
 
     #charset koi8-r;
     #access_log  /var/log/nginx/host.access.log  main;


### PR DESCRIPTION
- gdのインストール時のjpegライブラリ参照ディレクトリを明示します
- flarumはアバターに2MBまで許容しているがnginxの受信サイズが1MBまでになっていたのでPHPのpost_max_sizeに合わせて8MBまで許容するようにします